### PR TITLE
Run `usethis::use_coverage()`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^\.github$
 ^_pkgdown\.yml$
 ^pkgdown$
+^codecov\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: gMCPmini
 Title: Graph Based Multiple Comparison Procedures (Minimized Version without Java Dependency)
 Version: 0.8-15
 Authors@R: c(
-    person("Yalin", "Zhu", role = c("aut", "cre"), email = "yalin.zhu@merck.com", 
+    person("Yalin", "Zhu", role = c("aut", "cre"), email = "yalin.zhu@merck.com",
            comment = c(ORCID = "0000-0003-3830-8660")),
     person("Yilong", "Zhang", role = c("aut")),
     person("Xuan", "Deng", role = c("aut"), email = "xuan.deng@merck.com"),
@@ -11,31 +11,32 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-0250-5673")),
     person("Kornelius", "Rohmeyer", role = c("ctb"),  email = "rohmeyer@small-projects.de",
            comment = "gMCP author"),
-	  person("Florian", "Klinglmueller", role = c("ctb"), email = "float@lefant.net",
+    person("Florian", "Klinglmueller", role = c("ctb"), email = "float@lefant.net",
            comment = "gMCP author")
     )
 Description: Selected functions from the 'gMCP' package to support 'gsDesign'
     and remove the Java dependency. The package version is the same as the
     'gMCP' package version.
-Depends: R (>= 3.6.0)
 License: GPL (>= 2)
 URL: https://allenzhuaz.github.io/gMCPmini/, https://github.com/allenzhuaz/gMCPmini
 BugReports: https://github.com/allenzhuaz/gMCPmini/issues
 Encoding: UTF-8
 VignetteBuilder: knitr
+Depends: R (>= 3.6.0)
 Imports:
     ggplot2,
+    graphics,
     grDevices,
     grid,
-    graphics,
     MASS,
     methods,
     mvtnorm,
     stats,
     utils
 Suggests:
-    gsDesign,
+    covr,
     dplyr,
+    gsDesign,
     gt,
     kableExtra,
     knitr,

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
This PR runs `usethis::use_coverage()`.

It mostly added `covr` to `Suggests` and added a `codecov.yml` file which makes the code coverage checks in PRs informational (non-failing) even if it is decreasing. This is preferred as it's annoying when a 0.01% decrease is marked as fail.